### PR TITLE
Fixed Solr startup.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,13 @@ ENV TERM xterm
 
 ENV TERM xterm
 
+#The solr config file needs to be added after installation or it fails.
+ADD docker_files/solr /etc/default/solr.docker
+
 RUN \
     chmod +x /tmp/cdh_installer.sh && \
     chmod +x /usr/bin/cdh_startup_script.sh && \
     bash /tmp/cdh_installer.sh
-
-#The solr config file needs to be added after installation or it fails.
-ADD docker_files/solr /etc/default/solr
 
 # private and public mapping
 EXPOSE 8020:8020

--- a/docker_files/cdh_installer.sh
+++ b/docker_files/cdh_installer.sh
@@ -63,6 +63,8 @@ sed -i 's/secret_key=/secret_key=_S@s+D=h;B,s$C%k#H!dMjPmEsSaJR/g' /etc/hue/conf
 DEBIAN_FRONTEND=noninteractive apt-get -y install solr-server hue-search
 sudo -u hdfs hadoop fs -mkdir /solr
 sudo -u hdfs hadoop fs -chown solr /solr
+mv /etc/default/solr.docker /etc/default/solr
+service hbase-master start
 solrctl init
 
 


### PR DESCRIPTION
Put solr config on image before solr install with temporary name (so solr-server install doesn't fail). After solr install replace config from install, start hbase (so zookeeper is running) and run solrctl init.
